### PR TITLE
DXP-614 indexing from published pages

### DIFF
--- a/blocks/blog/blog.js
+++ b/blocks/blog/blog.js
@@ -1,9 +1,9 @@
 const renderMainArticle = ({
-  link, img, heading, avatar, author, date, readTime, description,
+  path, img, heading, avatar, author, date, readTime, description,
 }) => {
   const articleFragment = document.createRange().createContextualFragment(`
     <a
-      href="${link}"
+      href="${path}"
       class="article-featured"
     >
       <div class="columns is-desktop">
@@ -46,11 +46,11 @@ const renderMainArticle = ({
 };
 
 const renderArticle = ({
-  link, img, heading, author, date, readTime,
+  path, img, heading, author, date, readTime,
 }) => {
   const articleFragment = document.createRange().createContextualFragment(`
     <a
-      href="${link}"
+      href="${path}"
       class="column is-4-desktop article-thumbnail"
     >
       <div class="has-text-centered image-hero">
@@ -84,6 +84,7 @@ export default async function decorate(block) {
 
   try {
     blog = await (await fetch(blogLink)).json();
+    console.log(blog.data);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);

--- a/blocks/blog/blog.js
+++ b/blocks/blog/blog.js
@@ -84,7 +84,6 @@ export default async function decorate(block) {
 
   try {
     blog = await (await fetch(blogLink)).json();
-    console.log(blog.data);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: /query-index.json
+    target: /query-index.gsheet
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: /query-index.json
+    target: /query-index
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   blog:
     include:
       - /pages/articles/**
-    target: /query-index
+    target: /query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,8 +1,8 @@
 indices:
-  default:
+  blog:
     include:
       - /pages/articles/**
-    target: /drafts/mszeszko/query-index.json
+    target: /drafts/mszeszko/query-index
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   blog:
     include:
       - /pages/articles/**
-    target: /drafts/mszeszko/query-index
+    target: /query-index
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,7 +1,8 @@
 indices:
   default:
     include:
-      - /pages/**
+      - /pages/articles/**
+    target: /pages/articles-list.json
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -4,10 +4,10 @@ indices:
       - /pages/articles/**
     target: /query-index.json
     properties:
-      title:
+      heading:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")
-      image:
+      img:
         select: head > meta[property="og:image"]
         value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
       author:
@@ -21,4 +21,10 @@ indices:
         value: attribute(el, "content")
       date:
         select: head > meta[name="date"]
+        value: attribute(el, "content")
+      link:
+        select: head > meta[name="all-posts-link"]
+        value: attribute(el, "content")
+      description:
+        select: head > meta[name="description"]
         value: attribute(el, "content")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,8 +1,7 @@
 indices:
   default:
     include:
-      - /pages/articles/**
-    target: /query-index
+      - /pages/**
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: /query-index.xlsx
+    target: /query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,24 @@
+indices:
+  default:
+    include:
+      - /pages/articles/**
+    target: /query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      author:
+        select: head > meta[name="author"]
+        value: attribute(el, "content")
+      readTime:
+        select: head > meta[name="read-time"]
+        value: attribute(el, "content")
+      avatar:
+        select: head > meta[name="avatar"]
+        value: attribute(el, "content")
+      date:
+        select: head > meta[name="date"]
+        value: attribute(el, "content")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: '/query-index.json'
+    target: /query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: /query-index.gsheet
+    target: '/query-index.json'
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: /pages/articles-list.json
+    target: /query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -2,7 +2,7 @@ indices:
   default:
     include:
       - /pages/articles/**
-    target: /query-index.json
+    target: /drafts/mszeszko/query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+user-agent: *
+allow: /

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,0 @@
-user-agent: *
-allow: /


### PR DESCRIPTION
Fix [DXP-614](https://teamds.atlassian.net/browse/DXP-614)

Test URLs:
- Before: https://main--puresight-demo--websight-rnd.hlx.page/pages/blog
- After: https://dxp-614-new--puresight-demo--websight-rnd.hlx.page/drafts/mszeszko/blog-test

pages/blog uses `pages/articles-list.json` and my draft blog-test page uses `query-index.json`

Change to be done after merge: change path in pages/blog (author) and (optionally) remove blog-test doc

**[Blog-test](https://dxp-614-new--puresight-demo--websight-rnd.hlx.page/drafts/mszeszko/blog-test) does not have all information about articles because json has only information about published pages on `main` and main branch has old default configuration (after merging, data should be complete).**
