### PR TITLE
DXP-613 Initial publish-to-streamx workflow

### DIFF
--- a/.github/workflows/publish-to-streamx.yaml
+++ b/.github/workflows/publish-to-streamx.yaml
@@ -1,0 +1,13 @@
+name: Publish to StreamX
+
+on:
+  repository_dispatch:
+    types:
+      - resource-published
+jobs:
+  check-event-status:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Status: ${{ github.event.client_payload.status }}"
+          echo "Path: ${{ github.event.client_payload.path }}"


### PR DESCRIPTION
It's work in progress but according to GitHub documentation:

```
Note: This event will only trigger a workflow run if the workflow file is on the default branch.
```

So let's create the workflow file and see what we can do next.

Workflow should be triggered while publishing any page, for example:

https://dxp-613-streamx--puresight-demo--websight-rnd.hlx.page/pages/articles/streamx-test-article